### PR TITLE
Use which_applications() instead of start()

### DIFF
--- a/nagios_erlang.erl
+++ b/nagios_erlang.erl
@@ -73,16 +73,18 @@ check_application_inner(Node, Application) when is_list(Node) ->
 check_application_inner(Node, Application) when is_list(Application) ->    
     check_application_inner(Node, list_to_atom(Application));
 check_application_inner(Node, Application) ->
-    case rpc:call(Node, application, start, [Application], ?RPC_TIMEOUT) of
-	{badrpc, timeout} ->
-	    {warning, "Node ~p did not respond within ~p milliseconds.~n", [Node, ?RPC_TIMEOUT]};
-	{badrpc, _} ->
-	    {critical, "Couldn't contact Node ~p.~n", [Node]};
-	{error, {already_started, Application}} ->
-	    {ok, "Application ~p running on Node ~p.~n", [Application, Node]};
-	%% @todo move the {application_started ???} -> critical, _Other -> unknown
-	_Other ->
-	    {critical, "Application ~p not running on Node ~p.~n", [Application, Node]}
+    case rpc:call(Node, application, which_applications, [], ?RPC_TIMEOUT) of
+    	{badrpc, timeout} ->
+    	    {warning, "Node ~p did not respond within ~p milliseconds.~n", [Node, ?RPC_TIMEOUT]};
+    	{badrpc, _} ->
+    	    {critical, "Couldn't contact Node ~p.~n", [Node]};
+        Applist ->
+            case lists:keyfind(Application, 1, Applist) of
+                false ->
+                    {critical, "Application ~p not running on Node ~p.~n", [Application, Node]};
+                _Appentry ->
+	                {ok, "Application ~p running on Node ~p.~n", [Application, Node]}
+            end
     end.
 
 %% @doc Check status of a remote node's pg2 groups  and return Nagios friendly response.


### PR DESCRIPTION
This removes the side-effect of starting a possibly not-yet-started
or restarting a deliberately-stopped application, just to probe its
status, which would also have been returning a false-positive
(the application should have been noted as down).
